### PR TITLE
Add missing dependencies to package.xml

### DIFF
--- a/boxer_control/package.xml
+++ b/boxer_control/package.xml
@@ -23,12 +23,15 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
+  <exec_depend>interactive_marker_twist_server</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>nodelet</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>twist_mux</exec_depend>
 
   <test_depend>roslaunch</test_depend>
   <test_depend>roslint</test_depend>


### PR DESCRIPTION
Add missing exec_depends. Should resolve the warnings with releasing cpr_gazebo